### PR TITLE
knp-menu caused install problem, removed entry

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -91,11 +91,6 @@
             "source-reference": "b564463433aed66e9dddad8cbb761afff5a80cb4"
         },
         {
-            "package": "knplabs/knp-menu",
-            "version": "dev-master",
-            "source-reference": "d7a5eafa6711351b5989bd86bfa74d058e6a55ec"
-        },
-        {
             "package": "knplabs/knp-menu-bundle",
             "version": "dev-master",
             "source-reference": "c20933d2b988a3bd0944a0fd9e00068c30f0d27f"


### PR DESCRIPTION
Problems:
                - Problem caused by:
                        - Install command rule (+knplabs/knp-menu-bundle-9999999-dev|+knplabs/knp-menu-bundle-9999999-dev)
                        - Installation of package "knplabs/knp-menu-bundle" with constraint == 9999999-dev was requested. Satisfiable by packages [knplabs/knp-menu-bundle-9999999-dev, knplabs/knp-menu-bundle-9999999-dev].
                        - Package "knplabs/knp-menu-bundle-9999999-dev" contains the rule knplabs/knp-menu-bundle requires knplabs/knp-menu ([> 1.0.9999999.9999999, < 1.1.9999999.9999999]). Any of these packages satisfy the dependency: knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev), knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev).
                        - Package "knplabs/knp-menu-bundle-9999999-dev" contains the rule knplabs/knp-menu-bundle requires knplabs/knp-menu ([> 1.0.9999999.9999999, < 1.1.9999999.9999999]). Any of these packages satisfy the dependency: knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev), knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev).
                        - -knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev)|-knplabs/knp-menu-9999999-dev
                        - -knplabs/knp-menu-9999999-dev|-knplabs/knp-menu-1.1.9999999.9999999-dev (alias of 9999999-dev)
                        - Install command rule (+knplabs/knp-menu-9999999-dev)
                        - Installation of package "knplabs/knp-menu" with constraint == 9999999-dev was requested. Satisfiable by packages [knplabs/knp-menu-9999999-dev].
